### PR TITLE
Fix crashes in 'svd' with Toshiba SVD xml file.

### DIFF
--- a/SVD/pysvd.py
+++ b/SVD/pysvd.py
@@ -39,12 +39,20 @@ class SVDPeripheral:
 		except KeyError:
 			# This doesn't inherit registers from anything
 			registers = svd_elem.registers.getchildren()
-			self.description = svd_elem.description
+			self.description = str(svd_elem.description)
 			self.name = str(svd_elem.name)
 			self.registers = {}
 			for r in registers:
 				self.registers[str(r.name)] = SVDPeripheralRegister(r, self)
 			return
+		try:
+			self.name = str(svd_elem.name)
+		except:
+			self.name = parent.peripherals[derived_from].name
+		try:
+			self.description = str(svd_elem.description)
+		except:
+			self.description = parent.peripherals[derived_from].description
 		self.registers = deepcopy(parent.peripherals[derived_from].registers)
 		self.refactor_parent(parent)
 


### PR DESCRIPTION
I downloaded PyCortexMDebug today to try it out with my system, and I got some crashes out of the box trying to run the `svd` command.  This patch contains the fixes I needed to make:
1. apparently sometimes p.description wasn't a string.  Adding a `str()` call in pysvd.py makes it work.
2. try getting the `name` and `description` fields even for derived peripherals

Hopefully these changes won't break anything - let me know if you have any other changes/suggestions you'd like to see before pulling.
