### PR TITLE
Fixes the No module named 'svd' error

### DIFF
--- a/cmdebug/svd_gdb.py
+++ b/cmdebug/svd_gdb.py
@@ -21,7 +21,7 @@ import re
 import math
 import sys
 sys.path.append('.')
-from svd import SVDFile
+from cmdebug.svd import SVDFile
 
 #from svd_test import *
 


### PR DESCRIPTION
Is necessary to use the library namespace when importing other modules of the same library (installed via setup.py).