### PR TITLE
Skip PeripheralRegister creation only when there is no children

### DIFF
--- a/cmdebug/svd.py
+++ b/cmdebug/svd.py
@@ -109,8 +109,12 @@ class SVDPeripheralRegister:
 			fields = svd_elem.fields.getchildren()
 			for f in fields:
 				self.fields[str(f.name)] = SVDPeripheralRegisterField(f, self)
-		except:
-			pass
+		except AttributeError:
+		        if fields:
+                                raise
+		        else:
+                                # if node has no field, skip
+                                pass
 
 	def refactor_parent(self, parent):
 		self.parent = parent


### PR DESCRIPTION
Do not 'pass' all exception as it could mask some bugs (and in my
case, it did).

It helps when debugging...