### PR TITLE
Convert a map to a list [python3]

### DIFF
--- a/cmdebug/svd.py
+++ b/cmdebug/svd.py
@@ -201,7 +201,7 @@ class SVDPeripheralRegisterField:
 			self.width = int(str(svd_elem.bitWidth))
 		except:
 			try:
-				bitrange = map(int, str(svd_elem.bitRange).strip()[1:-1].split(":"))
+				bitrange = list(map(int, str(svd_elem.bitRange).strip()[1:-1].split(":")))
 				self.offset = bitrange[1]
 				self.width = 1 + bitrange[0] - bitrange[1]
 			except:


### PR DESCRIPTION
In python3, map objects are iterators and can't be accessed as an simple list. The list() function converts the iterator to a list and keeps compatibility with python2.

I have stumbled upon this problem with this file [LPC176x5x_v0.2.svd](https://github.com/posborne/cmsis-svd/blob/master/data/NXP/LPC176x5x_v0.2.svd), as it uses bitRanges instead bitOffset + bitWidth.

Modern gdb builds use python3, but there are many toolchains relying on python2, so it is a good idea to write code that can run on both.
