### PR TITLE
Fix handling non dimensioned clusters

### DIFF
--- a/cmdebug/svd.py
+++ b/cmdebug/svd.py
@@ -90,9 +90,9 @@ def add_cluster(parent, node):
 			offset += incr
 	else:
 		try:
-			parent.clusters[str(r.name)] = SVDRegisterCluster(node, parent)
-		except:
-			pass
+			parent.clusters[str(node.name)] = SVDRegisterCluster(node, parent)
+		except SVDNonFatalError as e:
+			print(e)
 
 class SVDRegisterCluster:
 	def __init__(self, svd_elem, parent):


### PR DESCRIPTION
Now ATSAMD21E18A.svd has a lot more peripherals supported.
This bug was introduced in last pull request https://github.com/bnahill/PyCortexMDebug/pull/26 commit https://github.com/bnahill/PyCortexMDebug/pull/26/commits/a6e09a4bedd570235d590bb8af7d2e53518b7aa8.

Also display exception if cluster parsing fails, instead of ignoring silently