### PR TITLE
Buff commandline with support for case-insensitive and prefix matching

### DIFF
--- a/cmdebug/svd.py
+++ b/cmdebug/svd.py
@@ -40,6 +40,9 @@ class SmartDict():
 
         return self.od[self.prefix_match(key)]
 
+    def is_ambiguous(self, key):
+        return key not in self.od and key not in self.casemap and len(list(self.prefix_match_iter(key))) > 1
+
     def prefix_match_iter(self, key):
         name, number = re.match('^(.*?)([0-9]*)$', key.lower()).groups()
         for entry, od_key in self.casemap.items():

--- a/cmdebug/svd.py
+++ b/cmdebug/svd.py
@@ -40,12 +40,15 @@ class SmartDict():
 
         return self.od[self.prefix_match(key)]
 
-    def prefix_match(self, key):
+    def prefix_match_iter(self, key):
         name, number = re.match('^(.*?)([0-9]*)$', key.lower()).groups()
         for entry, od_key in self.casemap.items():
             if entry.startswith(name) and entry.endswith(number):
-                return od_key
+                yield od_key
 
+    def prefix_match(self, key):
+        for od_key in self.prefix_match_iter(key):
+            return od_key
         return None
 
     def __setitem__(self, key, value):


### PR DESCRIPTION
This PR adds support for case-insensitive matching and prefix matching of peripheral, cluster, register and field names on the GDB commandline. This allows one to write e.g. `svd/x usart1 isr` or even `svd/x us1 isr` in place of shouting `svd/x USART1 ISR`.

Exact matches still work like before, so even if an SVD would define both `USART1` and `usArT1`, both can still be accessed by using their precise case spellings. case-insensitive or prefix matching will return the one defined further down in the SVD.

The prefix matcher parses the common syntax of `{peripheral_name}{peripheral_number}` like `USART3`, so both in tab completion and as an argument `us1` now matches `USART1`.

When a prefix matches multiple entries, the first one is used and a warning is printed.