### PR TITLE
Use pickle copier instead of deepcopy

### DIFF
--- a/cmdebug/svd.py
+++ b/cmdebug/svd.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 This file is part of PyCortexMDebug
 
@@ -18,9 +19,9 @@ along with PyCortexMDebug.  If not, see <http://www.gnu.org/licenses/>.
 
 import lxml.objectify as objectify
 import sys
-from copy import deepcopy
 from collections import OrderedDict
 import os
+import pickle
 import traceback
 import re
 import warnings
@@ -203,8 +204,12 @@ class SVDPeripheral:
 				self.description = str(svd_elem.description)
 			except:
 				self.description = parent.peripherals[derived_from].description
-			self.registers = deepcopy(parent.peripherals[derived_from].registers)
-			self.clusters = deepcopy(parent.peripherals[derived_from].clusters)
+
+			# pickle is faster than deepcopy by up to 50% on svd files with a
+			# lot of derivedFrom definitions
+			copier = lambda a: pickle.loads(pickle.dumps(a))
+			self.registers = copier(parent.peripherals[derived_from].registers)
+			self.clusters = copier(parent.peripherals[derived_from].clusters)
 			self.refactor_parent(parent)
 		else:
 			# This doesn't inherit registers from anything


### PR DESCRIPTION
For `derivedFrom` definitions deepcopy can get pretty slow. Use
`pickle.loads(pickle.dumps())` which is about 50% faster in my testing:

```plaintext
❯ hyperfine 'python3 svd.py lpc54628.svd' 'python3 svd_pickle.py lpc54628.svd'
Benchmark #1: python3 svd.py lpc54628.svd
  Time (mean ± σ):      5.206 s ±  0.331 s    [User: 5.177 s, System: 0.028 s]
  Range (min … max):    4.922 s …  5.815 s    10 runs

Benchmark #2: python3 svd_pickle.py lpc54628.svd
  Time (mean ± σ):      2.278 s ±  0.093 s    [User: 2.181 s, System: 0.096 s]
  Range (min … max):    2.111 s …  2.377 s    10 runs

Summary
  'python3 svd_pickle.py lpc54628.svd' ran
    2.29 ± 0.17 times faster than 'python3 svd.py lpc54628.svd'
```

As far as I know using `pickle` should be as safe as `deepcopy` here.

Also add a hashbang line since the `svd.py` file is marked executable.