### PR TITLE
Skip register read errors instead of crashing

### DIFF
--- a/cmdebug/svd_gdb.py
+++ b/cmdebug/svd_gdb.py
@@ -115,12 +115,15 @@ class SVD(gdb.Command):
 		regList = []
 		for r in regs_iter:
 			if r.readable():
-				data = self.read(r.address(), r.size)
-				data = self.format(data, form, r.size)
-				if form == 'a':
-					data += " <" + re.sub(r'\s+', ' ',
-						gdb.execute("info symbol {}".format(data), True,
-						True).strip()) + ">"
+				try:
+					data = self.read(r.address(), r.size)
+					data = self.format(data, form, r.size)
+					if form == 'a':
+						data += " <" + re.sub(r'\s+', ' ',
+							gdb.execute("info symbol {}".format(data), True,
+							True).strip()) + ">"
+				except gdb.MemoryError:
+					data = "(error reading)"
 			else:
 				data = "(not readable)"
 			desc = re.sub(r'\s+', ' ', r.description)


### PR DESCRIPTION
Register read errors yield an unhandled exception and crash. It's not
normally encountered, but in my case my part was in a Lockup state and
only certain memory regions are readable via the SWD-AP.

Instead of crashing on a register read error, report the value as
`(error reading)`. Tested:

```
(gdb) svd /x CoreDebug
Registers in CoreDebug:
        DHCSR:  (error reading)  Debug Halting Control and Status Register
        DCRSR:   (not readable)  Debug Core Register Selector Register
        DCRDR:  (error reading)  Debug Core Register Data Register
        DEMCR:       0x010017F1  Debug Exception and Monitor Control Register
```

Note that this patch only affects reading a peripheral; if reading or
writing an individual register, the error is unhandled, which I think
makes sense:

```
(gdb) svd /x CoreDebug DHCSR
Fields in CoreDebug DHCSR:
Python Exception <class 'gdb.MemoryError'> Cannot access memory at address 0xe000edf0:
Error occurred in Python: Cannot access memory at address 0xe000edf0
```