### PR TITLE
make dwt command sourcable by GDB

### DIFF
--- a/cmdebug/dwt_gdb.py
+++ b/cmdebug/dwt_gdb.py
@@ -153,3 +153,6 @@ class DWT(gdb.Command):
         gdb.write("\tDisplay the cycle count\n")
         gdb.write("\td(default):decimal, x: hex, o: octal, b: binary\n")
         return
+
+# Registers our class to GDB when sourced:
+DWT()


### PR DESCRIPTION
Without this commit, the dwt command was not available after source'ing the
file:

```
(gdb) source ~/src/PyCortexMDebug/cmdebug/dwt_gdb.py
(gdb) dwt
Undefined command: "dwt".  Try "help".
```

I think the SVD command was not affected because SVDLoad() is called over there.