### PR TITLE
Noahp/fix importing dwt gdb

### DIFF
--- a/cmdebug/dwt_gdb.py
+++ b/cmdebug/dwt_gdb.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 This file is part of PyCortexMDebug
 

--- a/cmdebug/dwt_gdb.py
+++ b/cmdebug/dwt_gdb.py
@@ -153,5 +153,9 @@ class DWT(gdb.Command):
         gdb.write("\td(default):decimal, x: hex, o: octal, b: binary\n")
         return
 
-# Registers our class to GDB when sourced:
-DWT()
+if __name__ == "__main__":
+    # This will also get executed by GDB
+
+    # Registers our class to GDB when sourced:
+    # Create just the svd_load command
+    DWT()

--- a/cmdebug/svd_gdb.py
+++ b/cmdebug/svd_gdb.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 This file is part of PyCortexMDebug
 


### PR DESCRIPTION
Couple of commits:

### Remove hashbangs from non-executable files

AFAIK these don't need to be executed outside of python import or gdb
sourcing, removing the hashbang lines (files aren't marked executable
anyway).

---

### Move DWT() register to only run when sourced

Pull request #37 instantiates the `DWT()` command when importing the
`dwt_gdb` module, which is a little different from how it works
elsewhere (see `svd_gdb.py`, and how the command is included in the
`scripts/gdb.py` file).

Move it inside main to match.