### PR TITLE
allow multiple spaces in svd command between arguments

### DIFF
--- a/cmdebug/svd_gdb.py
+++ b/cmdebug/svd_gdb.py
@@ -179,7 +179,7 @@ class SVD(gdb.Command):
             gdb.write("\n")
 
     def invoke(self, args, from_tty):
-        s = str(args).split(" ")
+        s = str(args).split()
         form = ""
         if s[0] and s[0][0] == '/':
             if len(s[0]) == 1:


### PR DESCRIPTION
Before this patch:

(gdb) svd AON_PMCTL  PWRCTL
Cluster  in peripheral AON_PMCTL does not exist!

but "svd AON_PMCTL PWRCTL" works as intended

Note the difference is two spaces ("does not exist" output) versus a single space.