### PR TITLE
Allow running with just Python Standard Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ can download SVD files for different manufacturers
 I originally tested primarily with ST parts, then Freescale for a while. Now many vendor parts have been tested, each with their own quirks.
 If you run into a file that doesn't parse right, either make an issue and ask for help or fix it and push a patch.
 
-The implementation consists of two components -- An lxml-based parser module (svd.py) and a GDB file (svd_gdb).
+The implementation consists of two components -- A parser module (svd.py) and a GDB file (svd_gdb).
 I haven't yet worked out a perfect workflow for this, though it's quite easy to use when
 you already tend to have a GDB initialization file for starting up OpenOCD and the like.
 However your workflow works, just make sure to, in GDB:

--- a/cmdebug/svd_gdb.py
+++ b/cmdebug/svd_gdb.py
@@ -20,7 +20,6 @@ import re
 import math
 import sys
 import struct
-import pkg_resources
 
 sys.path.append('.')
 from cmdebug.svd import SVDFile
@@ -40,6 +39,7 @@ class LoadSVD(gdb.Command):
     def __init__(self):
         self.vendors = {}
         try:
+            import pkg_resources
             vendor_names = pkg_resources.resource_listdir("cmsis_svd", "data")
             for vendor in vendor_names:
                 fnames = pkg_resources.resource_listdir("cmsis_svd", "data/{}".format(vendor))

--- a/cmdebug/svd_gdb.py
+++ b/cmdebug/svd_gdb.py
@@ -143,6 +143,8 @@ class SVD(gdb.Command):
     def _print_register_fields(self, container_name, form, register):
         gdb.write("Fields in {}:\n".format(container_name))
         fields = register.fields
+        if len(fields) == 0:
+            return
         if not register.readable():
             data = 0
         else:

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,5 @@ setup(
 	license='GPL',
 	install_requires=[
 	  'setuptools',
-	  'lxml',
 	],
 )


### PR DESCRIPTION
I've struggled getting these utilities to work with the Zephyr SDK due to the Python version.

So here's a pull request that removes the lxml dependency in favour of Python Standard Library's ElementTree instead.