### PR TITLE
cmdebug: LoadSVD(): Fix exception in complete()

### DIFF
--- a/cmdebug/svd_gdb.py
+++ b/cmdebug/svd_gdb.py
@@ -62,11 +62,11 @@ class LoadSVD(gdb.Command):
 
         # "svd_load <tab>" or "svd_load ST<tab>"
         if num_args == 1:
-            prefix = word.lower()
+            prefix = "" if word is None else word.lower()
             return [vendor for vendor in self.vendors if vendor.lower().startswith(prefix)]
         # "svd_load STMicro<tab>" or "svd_load STMicro STM32F1<tab>"
         elif num_args == 2 and args[0] in self.vendors:
-            prefix = word.lower()
+            prefix = "" if word is None else word.lower()
             filenames = self.vendors[args[0]]
             return [fname for fname in filenames if fname.lower().startswith(prefix)]
         return gdb.COMPLETE_NONE


### PR DESCRIPTION
The parameter `word` may actually be `None`, as shown by this exception:

    (gdb) svd_load STraceback (most recent call last):
      File "/usr/lib/python3.12/site-packages/cmdebug/svd_gdb.py", line 65, in complete
        prefix = word.lower()
                 ^^^^^^^^^^
    AttributeError: 'NoneType' object has no attribute 'lower'

This lets prefix fall back to `""` in case word is `None` to fix the issue.